### PR TITLE
fixing mongo server depreciation warning

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,7 +112,8 @@ function tryConnection(){
         useNewUrlParser: true,
         connectTimeoutMS: 5000,
         reconnectTries : 10, 
-        reconnectInterval : 3000 
+        reconnectInterval : 3000,
+        useUnifiedTopology: true,
       }
     );
   } else {
@@ -121,7 +122,8 @@ function tryConnection(){
       { useNewUrlParser: true,
         reconnectTries : 10,
         reconnectInterval : 3000, 
-        connectTimeoutMS: 5000
+        connectTimeoutMS: 5000,
+        useUnifiedTopology: true,
        }
     );
   }


### PR DESCRIPTION
(node:15) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.